### PR TITLE
Enable App Store download link for Hide and Seek app

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,16 +52,13 @@ const year = new Date().getFullYear();
               Your job is to figure out where.
             </p>
             <div class="flex flex-wrap items-center gap-2 mt-2">
-              <div class="relative flex flex-col items-center">
-                <span class="opacity-30 grayscale cursor-not-allowed">
-                  <img
-                    src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
-                    alt="Download on the App Store"
-                    class="h-10"
-                  />
-                </span>
-                <span class="absolute -bottom-4 text-[10px] opacity-40">Coming Soon</span>
-              </div>
+              <a href="https://apps.apple.com/us/app/hide-and-seek-lost-books/id6759506027" target="_blank" rel="noopener noreferrer">
+                <img
+                  src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
+                  alt="Download on the App Store"
+                  class="h-10"
+                />
+              </a>
               <a href="https://play.google.com/store/apps/details?id=com.tenoctober.hideandseeklostbooks" target="_blank" rel="noopener noreferrer">
                 <img
                   src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"


### PR DESCRIPTION
## Summary
Activated the App Store download badge by converting it from a disabled placeholder state to a functional link, allowing users to download the Hide and Seek: Lost Books app from Apple's App Store.

## Changes
- Replaced the disabled "Coming Soon" App Store badge with an active download link
- Removed the relative positioning wrapper and "Coming Soon" overlay text
- Added direct link to the App Store app listing (ID: 6759506027)
- Maintained consistent styling and link behavior with the existing Google Play Store badge

## Implementation Details
- The App Store link follows the same pattern as the Google Play Store link already present in the component
- Includes proper accessibility attributes (`target="_blank"` and `rel="noopener noreferrer"`)
- Preserves the original badge image and styling

https://claude.ai/code/session_01DJEE7LWLSNWXCte5GQULfV