### PR TITLE
Fail prod build when PostHog env vars are missing

### DIFF
--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,11 +1,25 @@
 ---
-// PostHog analytics snippet
-// Uses is:inline to prevent Astro from processing the script
+const apiKey = import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN;
+const apiHost = import.meta.env.PUBLIC_POSTHOG_HOST;
+const isDev = import.meta.env.DEV;
+
+if (import.meta.env.PROD) {
+  const missing = [
+    !apiKey && "PUBLIC_POSTHOG_PROJECT_TOKEN",
+    !apiHost && "PUBLIC_POSTHOG_HOST",
+  ].filter(Boolean);
+  if (missing.length) {
+    throw new Error(
+      `PostHog env vars required for production builds are missing: ${missing.join(", ")}. ` +
+        `Set them in Cloudflare Pages → Settings → Environment variables (Production).`,
+    );
+  }
+}
 ---
-<script is:inline define:vars={{ apiKey: import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN, apiHost: import.meta.env.PUBLIC_POSTHOG_HOST, isDev: import.meta.env.DEV }}>
+<script is:inline define:vars={{ apiKey, apiHost, isDev }}>
   if (!isDev) {
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init(apiKey || '', {
+    posthog.init(apiKey, {
       api_host: apiHost,
       defaults: '2026-01-30'
     })


### PR DESCRIPTION
When PUBLIC_POSTHOG_HOST is unset, the inlined PostHog snippet
concatenates undefined into its loader src, producing 404s for
/lost-books/undefined/static/array.js (and /undefined/static/array.js
on the home page). Throw at build time in production so the deploy
fails loudly instead of shipping a broken script tag.

Requires PUBLIC_POSTHOG_PROJECT_TOKEN and PUBLIC_POSTHOG_HOST to be
set in Cloudflare Pages env for any production deploy.